### PR TITLE
Implement level split type

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ The `"start"` split may include a condition that causes the run to start.
 }
 ```
 
+### Level
+
+`"level"` checks for the start of a level up animation for a particular level. Levels can be bounded with `"above"`, `"below"`, and/or `"equal"`.
+
+#### Example
+```json
+{
+	"splits": [{
+		"type": "level",
+		"equal": 15
+	}]
+}
+```
+
 ### Preset
 
 `"preset"` checks if a specific preset was loaded (see [CCPresetRevival](https://github.com/CCDirectLink/CCPresetRevival)). `"name"` will be checked against the `"title"` property of the loaded preset.

--- a/timer/eventManager.js
+++ b/timer/eventManager.js
@@ -22,6 +22,7 @@ export class EventManager {
 		Hook.startPresetButton((preset, slotIndex) => this._onStartPresetButton(preset, slotIndex));
 		Hook.update(() => this._update());
 		Hook.enemyHP((name, hp) => { this._check({ type: 'damage', name, hp }) });
+		Hook.levelUp((level) => { this._check({ type: 'level', level })});
 		Hook.teleport((mapName) => { this._check({ type: 'teleport', mapName }) });
 		Hook.varChanged(() => { this._check({ type: 'vars' }) });
 		window.addEventListener('unload', () => this.onunload());
@@ -181,6 +182,20 @@ export class EventManager {
 				return [true, event.once];
 			}
 			break;
+		}
+		case 'level': {
+			if(action && action.type === 'level') {
+				if(typeof event.below === 'number' && action.level > event.below) {
+					break;
+				}
+				if(typeof event.above === 'number' && action.level < event.above) {
+					break;
+				}
+				if(typeof event.equal === 'number' && action.level !== event.equal) {
+					break;
+				}
+				return [true, event.once];
+			}
 		}
 		case 'preset': {
 			if(action && action.type === 'preset' && action.presetName === event.name) {

--- a/timer/hooks.js
+++ b/timer/hooks.js
@@ -85,4 +85,14 @@ export class Hook {
 			}
 		});
 	}
+
+	static levelUp(callback) {
+		ig.GUI.LevelUpHud.inject({
+			init: function(...args) {
+				const result = this.parent(...args);
+				callback(sc.model.player.level);
+				return result;
+			}
+		});
+	}
 }


### PR DESCRIPTION
This was necessary for making a proper autosplitter for the Level 99 run. 

There is technically an event that already exists tracking the start / end of the level up animation, but there was not enough information to attempt to bound the split event without associating it with the level you reach.